### PR TITLE
Fix for NaN values produced by sensitivity analysis

### DIFF
--- a/dmosopt/MOASMO.py
+++ b/dmosopt/MOASMO.py
@@ -243,7 +243,7 @@ def epoch(
             try:
                 if feasibility_model:
                     logger.info(f"Constructing feasibility model...")
-                    fsbm = LogisticFeasibilityModel(Xinit, C)
+                    fsbm = LogisticFeasibilityModel(x, C)
                 x = x[feasible, :]
                 y = y[feasible, :]
             except:
@@ -418,6 +418,7 @@ def train(
             if logger is not None:
                 logger.info(f"Found {len(feasible)} feasible solutions")
 
+
     x, y = MOEA.remove_duplicates(x, y)
 
     # resolve shorthands
@@ -469,6 +470,7 @@ def analyze_sensitivity(
                 ]
             )
         )
+        S1s = np.nan_to_num(S1s, copy=False)
         S1max = np.max(S1s, axis=0)
         S1nmax = S1max / np.max(S1max)
         di_mutation = np.clip(S1nmax * di_max, di_min, None)

--- a/dmosopt/dmosopt.py
+++ b/dmosopt/dmosopt.py
@@ -1180,6 +1180,15 @@ class DistOptimizer:
                     for problem_id in self.problem_ids:
                         self.eval_reqs[problem_id][task_id] = eval_req_dict[problem_id]
 
+        if (
+                self.save
+                and (self.eval_count > 0)
+                and (self.saved_eval_count < self.eval_count)
+                and ((self.eval_count - self.saved_eval_count) >= self.save_eval)
+            ):
+                self.save_evals()
+                self.saved_eval_count = self.eval_count
+
         assert len(task_ids) == 0
         return self.eval_count, self.saved_eval_count
 

--- a/dmosopt/dmosopt.py
+++ b/dmosopt/dmosopt.py
@@ -271,6 +271,8 @@ class DistOptStrategy:
         if self.termination is not None:
             self.termination.reset()
 
+        completed_evals = self._update_evals()
+
         assert epoch_index > self.epoch_index
         self.epoch_index = epoch_index
         self.opt_gen = opt.epoch(

--- a/dmosopt/dmosopt.py
+++ b/dmosopt/dmosopt.py
@@ -1184,7 +1184,6 @@ class DistOptimizer:
                 self.save
                 and (self.eval_count > 0)
                 and (self.saved_eval_count < self.eval_count)
-                and ((self.eval_count - self.saved_eval_count) >= self.save_eval)
             ):
                 self.save_evals()
                 self.saved_eval_count = self.eval_count


### PR DESCRIPTION
Some surrogate models, such as the ones constructed with scikit-learn, produce nans if the input values are outside of the observed range, which in turn produces sensitivity analysis values of nan. This PR converts nan values to 0 in the sensitivity analysis output.