### PR TITLE
Fix invalid feature indexing in _reduce_evals

### DIFF
--- a/dmosopt/dmosopt.py
+++ b/dmosopt/dmosopt.py
@@ -195,6 +195,9 @@ class DistOptStrategy:
         if self.c is not None:
             self.c = self.c[~is_duplicates]
 
+        if self.f.ndim == 1:
+            self.f = self.f[:, None] 
+
     def _reduce_evals(self):
 
         self._remove_duplicate_evals()

--- a/dmosopt/dmosopt.py
+++ b/dmosopt/dmosopt.py
@@ -204,7 +204,7 @@ class DistOptStrategy:
         self.x = self.x[perm[0 : self.population_size], :]
         self.y = self.y[perm[0 : self.population_size], :]
         if self.c is not None:
-            self.c = self.c[perm[0 : self.population_size]]
+            self.c = self.c[perm[0 : self.population_size], :]
         if self.f is not None:
             self.f = self.f[perm[0 : self.population_size]]
 

--- a/dmosopt/dmosopt.py
+++ b/dmosopt/dmosopt.py
@@ -195,9 +195,6 @@ class DistOptStrategy:
         if self.c is not None:
             self.c = self.c[~is_duplicates]
 
-        if self.f.ndim == 1:
-            self.f = self.f[:, None] 
-
     def _reduce_evals(self):
 
         self._remove_duplicate_evals()
@@ -207,9 +204,9 @@ class DistOptStrategy:
         self.x = self.x[perm[0 : self.population_size], :]
         self.y = self.y[perm[0 : self.population_size], :]
         if self.c is not None:
-            self.c = self.c[perm[0 : self.population_size], :]
+            self.c = self.c[perm[0 : self.population_size]]
         if self.f is not None:
-            self.f = self.f[perm[0 : self.population_size], :]
+            self.f = self.f[perm[0 : self.population_size]]
 
     def _update_evals(self):
         result = None


### PR DESCRIPTION
This should fix the following issue:

```
INFO:distwq:MPI controller : received result for call with id 21677 ...
INFO:dmosopt:problem id 0: optimization epoch 0: parameters [('gc', 1.9690386363636363), ('soma_gmax_Na', 0.13843181818181818), ('soma_gmax_K', 0.2601052272727272), ('soma_gmax_KCa', 0.006869125), ('soma_gmax_CaN', 0.005350264772727272), ('soma_g_pas', 0.0006632097727272728), ('dend_gmax_CaL', 0.0008722675000000001), ('dend_gmax_CaN', 0.0009448974999999999), ('dend_gmax_KCa', 0.004793643181818181), ('dend_g_pas', 0.00016961295454545456), ('cm_ratio', 30.36965909090909)]: [('rn_error', nan), ('tau_error', nan), ('fI_error', 67.68423), ('spike_amplitude_error', 1121.8483), ('ISI_adaptation_error', 325.60602)] / [{'ic_constant_hold': -0.10013884, 'ic_constant_rest': -0.10378367, 'initial_v_error_hold': -4.294039, 'rn': nan, 'tau': nan, 'fI': array([(5.,), (6.,), (6.,), (6.,), (6.,), (6.,), (6.,)],
      dtype=[('frequency', '<f8')]), 'mean_fI_diff': 67.68423, 'ISI': array([(196.5 , 196.72, 1.00111959, 196.6575, 0.09120718, 5),
       (187.19, 188.66, 1.00785298, 188.38  , 0.59514704, 6),
       (180.22, 182.59, 1.01315059, 182.122 , 0.95128124, 6),
       (174.12, 177.37, 1.01866529, 176.738 , 1.30934182, 6),
       (168.46, 172.71, 1.02522854, 171.884 , 1.71250226, 6),
       (163.13, 168.46, 1.03267333, 167.418 , 2.14475546, 6),
       (157.95, 164.51, 1.04153213, 163.238 , 2.64514196, 6)],
      dtype=[('first', '<f8'), ('last', '<f8'), ('ratio', '<f8'), ('mean', '<f8'), ('std', '<f8'), ('N', '<i8')]), 'threshold': array([-35.40465 , -35.44712 , -35.535507, -35.607   , -35.69606 ,
       -35.62192 , -35.67157 ], dtype=float32), 'spike_amplitude': array([20.18512 , 24.47345 , 26.414543, 27.678356, 28.648336, 29.273815,
       29.902151], dtype=float32)}] constr: [('monotonic_fI', -1.0), ('rn_constr', -1.0), ('tau_constr', -1.0), ('spike_amplitude_constr', 1.0), ('first_ISI_constr', 1.0), ('ISI_adaptation_constr', 1.0), ('pre_spk_count', -1.0), ('initial_v_constr', -1.0)]
INFO:default:Saving 1 evaluations for problem id 0 to /dmosopt.h5.
Traceback (most recent call last):
  File "./site-packages/machinable/component.py", line 162, in dispatch
    self.__call__()
  File "/scratch1/08818/fg14/storage/4da938de25ba-0008-d1d7-eb54-7864a560/047274/source_code/interface/dmosopt.py", line 208, in __call__
    dmosopt.run(
  File "./site-packages/dmosopt/dmosopt.py", line 2063, in run
    distwq.run(
  File "./site-packages/distwq.py", line 2071, in run
    fun(controller, *args)
  File "./site-packages/dmosopt/dmosopt.py", line 2032, in dopt_ctrl
    dopt.run_epoch()
  File "./site-packages/dmosopt/dmosopt.py", line 1209, in run_epoch
    self.optimizer_dict[problem_id].initialize_epoch(epoch)
  File "./site-packages/dmosopt/dmosopt.py", line 312, in initialize_epoch
    self._reduce_evals()
  File "./site-packages/dmosopt/dmosopt.py", line 209, in _reduce_evals
    self.f = self.f[perm[0 : self.population_size], :]
IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed

```