### PR TITLE
Add top-k data subsampling option

### DIFF
--- a/dmosopt/MOEA.py
+++ b/dmosopt/MOEA.py
@@ -348,6 +348,31 @@ def orderMO(
     return perm, rank, y_dists
 
 
+def top_k_MO(x, y, top_k=None):
+    """Returns the top_k elements ordered by a non-dominated sort for multi-objective optimization
+    x: input parameter matrix
+    y: output objectives matrix
+    top_k: number of top elements. If None, all elements will be returned
+    """
+    if not isinstance(top_k, int):
+        return x, y
+
+    if x.shape[0] <= top_k:
+        return x, y
+
+    x_, y_, *_ = sortMO(x, y)
+    if x_.shape[0] >= top_k:
+        x = x_[:top_k]
+        y = y_[:top_k]
+    else:
+        # if sortMO yields less than top-k
+        #  we fall back on regular top-k
+        x = x[-top_k:]
+        y = y[-top_k:]
+
+    return x, y
+
+
 def crowding_distance(Y):
     """Crowding distance metric.
     Y is the output data matrix


### PR DESCRIPTION
A number of the surrogate models suffer from poor scaling in the number of samples (e.g. GPR relies on O(n3) covariance matrix inversion etc.)

This adds an option to reduce the number of training samples by picking the top-k with respect to non-dominated sorting, as we want the model to learn on the high-quality current-best samples.