### PR TITLE
Fix stale save_to_h5 signatures and handle missing opt_id gracefully

### DIFF
--- a/dmosopt/dmosopt.py
+++ b/dmosopt/dmosopt.py
@@ -820,7 +820,6 @@ class DistOptimizer:
                     self.problem_ids,
                     self.has_problem_ids,
                     self.param_space,
-                    self.param_names,
                     self.objective_names,
                     self.feature_dtypes,
                     self.constraint_names,
@@ -1790,6 +1789,42 @@ def h5_init_types(
     dset[:] = param_path_array
 
 
+def h5_init_opt_group(
+    f,
+    opt_id,
+    objective_names,
+    feature_dtypes,
+    constraint_names,
+    problem_parameters,
+    parameter_space,
+    problem_ids,
+    has_problem_ids,
+    metadata,
+    random_seed,
+    surrogate_mean_variance=False,
+):
+    if opt_id in f.keys():
+        return
+    h5_init_types(
+        f,
+        opt_id,
+        objective_names,
+        feature_dtypes,
+        constraint_names,
+        problem_parameters,
+        parameter_space,
+        surrogate_mean_variance=surrogate_mean_variance,
+    )
+    opt_grp = h5_get_group(f, opt_id)
+    if metadata is not None:
+        opt_grp["metadata"] = metadata
+    opt_grp["problem_ids"] = np.asarray(
+        list(problem_ids) if has_problem_ids else [0], dtype=np.int32
+    )
+    if random_seed is not None:
+        opt_grp["random_seed"] = np.asarray([random_seed], dtype=np.int32)
+
+
 def h5_load_raw(input_file, opt_id):
     ## N is number of trials
     ## M is number of hyperparameters
@@ -2028,7 +2063,7 @@ def save_to_h5(
     problem_ids,
     has_problem_ids,
     objective_names,
-    feature_names,
+    feature_dtypes,
     constraint_names,
     parameter_space,
     evals,
@@ -2044,25 +2079,20 @@ def save_to_h5(
     """
 
     f = h5py.File(fpath, "a")
-    if opt_id not in f.keys():
-        h5_init_types(
-            f,
-            opt_id,
-            objective_names,
-            problem_parameters,
-            constraint_names,
-            parameter_space,
-            surrogate_mean_variance=surrogate_mean_variance,
-        )
-        opt_grp = h5_get_group(f, opt_id)
-        if metadata is not None:
-            opt_grp["metadata"] = metadata
-        if has_problem_ids:
-            opt_grp["problem_ids"] = np.asarray(list(problem_ids), dtype=np.int32)
-        else:
-            opt_grp["problem_ids"] = np.asarray([0], dtype=np.int32)
-        if random_seed is not None:
-            opt_grp["random_seed"] = np.asarray([random_seed], dtype=np.int32)
+    h5_init_opt_group(
+        f,
+        opt_id,
+        objective_names,
+        feature_dtypes,
+        constraint_names,
+        problem_parameters,
+        parameter_space,
+        problem_ids,
+        has_problem_ids,
+        metadata,
+        random_seed,
+        surrogate_mean_variance=surrogate_mean_variance,
+    )
 
     opt_grp = h5_get_group(f, opt_id)
 
@@ -2287,7 +2317,6 @@ def init_h5(
     problem_ids,
     has_problem_ids,
     parameter_space,
-    param_names,
     objective_names,
     feature_dtypes,
     constraint_names,
@@ -2302,24 +2331,20 @@ def init_h5(
     """
 
     f = h5py.File(fpath, "a")
-    if opt_id not in f.keys():
-        h5_init_types(
-            f,
-            opt_id,
-            objective_names,
-            feature_dtypes,
-            constraint_names,
-            problem_parameters,
-            parameter_space,
-            surrogate_mean_variance=surrogate_mean_variance,
-        )
-        opt_grp = h5_get_group(f, opt_id)
-        if has_problem_ids:
-            opt_grp["problem_ids"] = np.asarray(list(problem_ids), dtype=np.int32)
-        if metadata is not None:
-            opt_grp["metadata"] = metadata
-        if random_seed is not None:
-            opt_grp["random_seed"] = np.asarray([random_seed], dtype=np.int32)
+    h5_init_opt_group(
+        f,
+        opt_id,
+        objective_names,
+        feature_dtypes,
+        constraint_names,
+        problem_parameters,
+        parameter_space,
+        problem_ids,
+        has_problem_ids,
+        metadata,
+        random_seed,
+        surrogate_mean_variance=surrogate_mean_variance,
+    )
 
     f.close()
 

--- a/tests/test_save_to_h5.py
+++ b/tests/test_save_to_h5.py
@@ -1,0 +1,128 @@
+import tempfile
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from dmosopt import dmosopt
+from dmosopt.datatypes import ParameterSpace
+
+
+OPT_ID = "test"
+OBJECTIVE_NAMES = ["f0", "f1"]
+FEATURE_DTYPES = [("feature", np.float32)]
+
+
+def _make_inputs():
+    parameter_space = ParameterSpace.from_dict({"x": [0.0, 1.0], "y": [0.0, 1.0]})
+    problem_parameters = ParameterSpace.from_dict({}, is_value_only=True)
+
+    prob_evals_f = [
+        np.array([(0.5,)], dtype=FEATURE_DTYPES),
+        np.array([(0.6,)], dtype=FEATURE_DTYPES),
+    ]
+    evals = {
+        0: (
+            [0, 0],  # epochs
+            [(0.1, 0.2), (0.3, 0.4)],  # parameters (x, y)
+            [(1.0, 2.0), (3.0, 4.0)],  # objectives (f0, f1)
+            prob_evals_f,  # features
+            None,  # constraints
+            [(1.0, 2.0), (3.0, 4.0)],  # predictions
+        )
+    }
+    return parameter_space, problem_parameters, evals
+
+
+def _save_to_h5(fpath):
+    parameter_space, problem_parameters, evals = _make_inputs()
+    dmosopt.save_to_h5(
+        OPT_ID,
+        [0],  # problem_ids
+        False,  # has_problem_ids
+        OBJECTIVE_NAMES,
+        FEATURE_DTYPES,
+        None,  # constraint_names
+        parameter_space,
+        evals,
+        problem_parameters,
+        None,  # metadata
+        1,  # random_seed
+        str(fpath),
+        None,  # logger
+    )
+
+
+def _assert_well_formed(fpath):
+    with h5py.File(str(fpath), "r") as f:
+        grp = f[OPT_ID]
+        objective_enum = h5py.check_enum_dtype(grp["objective_enum"].dtype)
+        assert set(objective_enum.keys()) == set(OBJECTIVE_NAMES)
+        # feature_dtypes must survive round-trip: the group has a feature enum
+        # named after the dtype field, which the buggy call could never build.
+        feature_enum = h5py.check_enum_dtype(grp["feature_enum"].dtype)
+        assert set(feature_enum.keys()) == {"feature"}
+        assert grp["0/objectives"].shape[0] == 2
+        assert grp["0/features"].shape[0] == 2
+        assert list(grp["problem_ids"][:]) == [0]
+
+
+def test_save_to_h5_reinitializes_missing_group(tmp_path):
+    fpath = tmp_path / "truncated.h5"
+    with h5py.File(str(fpath), "w") as f:
+        f.create_group("unrelated")
+
+    _save_to_h5(fpath)  # must not raise
+    _assert_well_formed(fpath)
+
+
+def test_save_to_h5_fresh_file(tmp_path):
+    fpath = tmp_path / "fresh.h5"
+    _save_to_h5(fpath)
+    _assert_well_formed(fpath)
+
+
+def test_init_h5_and_save_to_h5_agree(tmp_path):
+    parameter_space, problem_parameters, _ = _make_inputs()
+
+    fpath = tmp_path / "init.h5"
+    dmosopt.init_h5(
+        OPT_ID,
+        [0],  # problem_ids
+        False,  # has_problem_ids
+        parameter_space,
+        OBJECTIVE_NAMES,
+        FEATURE_DTYPES,
+        None,  # constraint_names
+        problem_parameters,
+        None,  # metadata
+        1,  # random_seed
+        str(fpath),
+    )
+
+    with h5py.File(str(fpath), "r") as f:
+        grp = f[OPT_ID]
+        assert set(h5py.check_enum_dtype(grp["feature_enum"].dtype)) == {"feature"}
+        assert set(h5py.check_enum_dtype(grp["objective_enum"].dtype)) == set(
+            OBJECTIVE_NAMES
+        )
+        assert list(grp["problem_ids"][:]) == [0]
+
+    # Appending evaluations to the init_h5-created file must not re-init or crash.
+    _save_to_h5(fpath)
+    _assert_well_formed(fpath)
+
+
+def test_save_to_h5():
+    for test in (
+        test_save_to_h5_reinitializes_missing_group,
+        test_save_to_h5_fresh_file,
+        test_init_h5_and_save_to_h5_agree,
+    ):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test(Path(tmp_dir))
+        print(f"{test.__name__} PASSED")
+
+
+if __name__ == "__main__":
+    test_save_to_h5()


### PR DESCRIPTION
When restarting an interrupted run that had not written the opt_id, I noticed a signature mismatch in save_to_h5 where the argument order did not match the function signature. It probably drifted unnoticed during some earlier refactor but never surfaced since the opt_id is usually written.

This handles non-existing opt_id gracefully and adds a test to detect argument mismatches.